### PR TITLE
Link all dependencies in the vendor folder to the custom go building environment.

### DIFF
--- a/patches/0001-Link-all-dependencies-in-vendor-folder-to-the-custom.patch
+++ b/patches/0001-Link-all-dependencies-in-vendor-folder-to-the-custom.patch
@@ -1,0 +1,29 @@
+From 8743194c17706a8818a2243f39e5e4c0ba647d76 Mon Sep 17 00:00:00 2001
+From: gary-wzl77 <gary.wang@canonical.com>
+Date: Mon, 20 Nov 2017 14:03:48 +0800
+Subject: [PATCH] Link all dependencies in vendor folder to the custom go
+ building environment.
+
+---
+ GNUmakefile | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/GNUmakefile b/GNUmakefile
+index 2e9a11d..15b1d8d 100644
+--- a/GNUmakefile
++++ b/GNUmakefile
+@@ -73,5 +73,11 @@ static-assets:
+ 
+ tools:
+ 	go get -u -v $(GOTOOLS)
++	@for dep in $(shell cd vendor; find * -type d -maxdepth 2 -mindepth 2); do \
++	  echo "Linking $$dep into $$GOPATH"; \
++	  rm -rf $$GOPATH/src/$$dep; \
++		mkdir -p $$GOPATH/src/$${dep%/*}; \
++		ln -fs $(shell pwd)/vendor/$$dep $$GOPATH/src/$$dep; \
++	done
+ 
+ .PHONY: all ci bin dev dist cov test cover format vet ui static-assets tools
+-- 
+2.7.4
+

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -51,7 +51,8 @@ parts:
     plugin: shell
     source: git@github.com:hashicorp/consul.git
     # source: ./consul
-    # source-tag: v0.7.3
+    source-tag: v0.7.3
+    prepare: git apply $SNAPCRAFT_STAGE/0001-Link-all-dependencies-in-vendor-folder-to-the-custom.patch
     shell: bash
     shell-flags: ['-eux', '-o', 'pipefail']
     shell-command: |
@@ -66,7 +67,7 @@ parts:
       ln -s "$PWD" .gopath/src/github.com/hashicorp/consul
 
       pushd .gopath/src/github.com/hashicorp/consul
-      make dev
+      make bin
       popd
 
       consulBin='.gopath/src/github.com/hashicorp/consul/pkg/linux_amd64/consul'
@@ -75,5 +76,11 @@ parts:
       install -T "$(readlink -f "$consulBin")" "$SNAPCRAFT_PART_INSTALL/bin/consul"
     after:
       - go
+      - patch
     build-packages:
       - make
+  patch:
+    source: patches
+    plugin: dump
+    prime:
+      - -*


### PR DESCRIPTION
Leave a patch to create a bunch of soft link pointing to the custom go
building environment.