### PR TITLE
Delete duplicated key to have fully valid yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -86,7 +86,6 @@ parts:
     source: https://github.com/hashicorp/consul.git
     # source: ./consul
     source-tag: v0.7.3
-    after: [go]
     prepare: git apply $SNAPCRAFT_STAGE/0001-Link-all-dependencies-in-vendor-folder-to-the-custom.patch
     shell: bash
     shell-flags: ['-eux', '-o', 'pipefail']


### PR DESCRIPTION
This was preventing the build.snapcraft.io machines from being able to build my fork of this repo.
I'm using those machines to test changes as the build.snapcraft.io machines build faster than my local machine for arm builds; you can see builds here : https://build.snapcraft.io/user/anonymouse64/edgex-core-snap. Note that the snaps from those machines are auto-published to the edge channel under the registered name `edgexfoundry-core-ijohnson`.